### PR TITLE
Dockerize magnetico as a pair of conjoined containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "2"
+
+volumes:
+  shared_db:
+
+services:
+  magneticod:
+    build:
+      context: magneticod
+    volumes:
+      - shared_db:/root/.local/share
+
+  magneticow:
+    build:
+      context: magneticow
+    volumes:
+      - shared_db:/root/.local/share
+
+    ports:
+      - "12345:8080"

--- a/magneticod/.dockerignore
+++ b/magneticod/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+.dockerignore

--- a/magneticod/Dockerfile
+++ b/magneticod/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.6
+
+RUN mkdir -p /usr/src/app
+
+WORKDIR /usr/src/app
+
+COPY . .
+RUN pip install -e .
+CMD ["python", "-mmagneticod"]

--- a/magneticow/.dockerignore
+++ b/magneticow/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+.dockerignore

--- a/magneticow/Dockerfile
+++ b/magneticow/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.6
+
+RUN mkdir -p /usr/src/app
+
+WORKDIR /usr/src/app
+
+COPY . .
+RUN pip install -e .
+EXPOSE 8080
+CMD ["python", "-mmagneticow", "--port", "8080", "--user", "user", "password"]


### PR DESCRIPTION
docker-compose links them, they share a DB on a volume container, and
expose the web interface on the host port 12345