### PR TITLE
Fix magneticod on macOS.

### DIFF
--- a/magneticod/magneticod/bittorrent.py
+++ b/magneticod/magneticod/bittorrent.py
@@ -33,7 +33,8 @@ class DisposablePeer:
         self.__socket.setblocking(False)
         # To reduce the latency:
         self.__socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, True)
-        self.__socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_QUICKACK, True)
+        if hasattr(socket, 'TCP_QUICKACK'):
+            self.__socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_QUICKACK, True)
         res = self.__socket.connect_ex(peer_addr)
         if res != errno.EINPROGRESS:
             raise ConnectionError()


### PR DESCRIPTION
macOS lacks the `TCP_QUICKACK` option. Since this is simply an
optimization, we can safely skip it on macOS.