### PR TITLE
optimize find_nodes bencoding and random_bytes generation

### DIFF
--- a/magneticod/magneticod/bittorrent.py
+++ b/magneticod/magneticod/bittorrent.py
@@ -19,6 +19,7 @@ import math
 import socket
 import random
 import typing
+import os
 
 from . import bencode
 
@@ -287,4 +288,4 @@ class DisposablePeer:
 
     @staticmethod
     def __random_bytes(n: int) -> bytes:
-        return random.getrandbits(n * 8).to_bytes(n, "big")
+        return os.urandom(n)

--- a/magneticod/magneticod/dht.py
+++ b/magneticod/magneticod/dht.py
@@ -19,6 +19,7 @@ import logging
 import random
 import socket
 import typing
+import os
 
 from . import bencode
 
@@ -244,7 +245,7 @@ class SybilNode:
 
     @staticmethod
     def __random_bytes(n: int) -> bytes:
-        return random.getrandbits(n * 8).to_bytes(n, "big")
+        return os.urandom(n)
 
     def __build_FIND_NODE_query(self, id_: bytes) -> bytes:
         """ BENCODE IMPLEMENTATION

--- a/magneticod/magneticod/dht.py
+++ b/magneticod/magneticod/dht.py
@@ -211,27 +211,11 @@ class SybilNode:
 
     def __bootstrap(self) -> None:
         for addr in BOOTSTRAPPING_NODES:
-            self.__outgoing_queue.append((addr, bencode.dumps({
-                b"y": b"q",
-                b"q": b"find_node",
-                b"t": self.__random_bytes(2),
-                b"a": {
-                    b"id": self.__true_id,
-                    b"target": self.__random_bytes(20)
-                }
-            })))
+            self.__outgoing_queue.append((addr, self.__build_FIND_NODE_query(self.__true_id)))
 
     def __make_neighbours(self) -> None:
         for node_id, addr in self.__routing_table.items():
-            self.__outgoing_queue.append((addr, bencode.dumps({
-                b"y": b"q",
-                b"q": b"find_node",
-                b"t": self.__random_bytes(2),
-                b"a": {
-                    b"id": node_id[:15] + self.__true_id[:5],
-                    b"target": self.__random_bytes(20)
-                }
-            })))
+            self.__outgoing_queue.append((addr, self.__build_FIND_NODE_query(node_id[:15] + self.__true_id[:5])))
 
     @staticmethod
     def __decode_nodes(infos: bytes) -> typing.List[typing.Tuple[NodeID, NodeAddress]]:
@@ -261,3 +245,22 @@ class SybilNode:
     @staticmethod
     def __random_bytes(n: int) -> bytes:
         return random.getrandbits(n * 8).to_bytes(n, "big")
+
+    def __build_FIND_NODE_query(self, id_: bytes) -> bytes:
+        """ BENCODE IMPLEMENTATION
+        bencode.dumps({
+            b"y": b"q",
+            b"q": b"find_node",
+            b"t": self.__random_bytes(2),
+            b"a": {
+                b"id": id_,
+                b"target": self.__random_bytes(20)
+            }
+        })
+        """
+
+        """ Optimized Version """
+        return b"d1:ad2:id20:%s6:target20:%se1:q9:find_node1:t2:aa1:y1:qe" % (
+            id_,
+            self.__random_bytes(20)
+        )


### PR DESCRIPTION
96% speed up in find_nodes functions (__bootstrap & __make_neighbours) removing bencoding
31% speed up in random bytes generation (__random_bytes)

Fix #41, #45