### PR TITLE
Limit metadata size

### DIFF
--- a/magneticod/magneticod/__main__.py
+++ b/magneticod/magneticod/__main__.py
@@ -233,7 +233,7 @@ def parse_cmdline_arguments() -> typing.Optional[argparse.Namespace]:
     default_database_dir = os.path.join(appdirs.user_data_dir("magneticod"), "database.sqlite3")
     parser.add_argument(
         "--database-file", type=str, default=default_database_dir,
-        help="Path to database file (default: {})".format(default_database_dir)
+        help="Path to database file (default: {})".format(humanfriendly.format_path(default_database_dir))
     )
     parser.add_argument(
         '-d', '--debug',

--- a/magneticod/magneticod/__main__.py
+++ b/magneticod/magneticod/__main__.py
@@ -52,16 +52,14 @@ complete_info_hashes = set()
 def main():
     global complete_info_hashes, database, node, peers, selector
 
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s  %(levelname)-8s  %(message)s")
-    logging.info("magneticod v%d.%d.%d started", *__version__)
-
     arguments = parse_cmdline_arguments()
-    if arguments is None:
-        return 2
+
+    logging.basicConfig(level=arguments.loglevel, format="%(asctime)s  %(levelname)-8s  %(message)s")
+    logging.info("magneticod v%d.%d.%d started", *__version__)
 
     # noinspection PyBroadException
     try:
-        path =arguments.database_file
+        path = arguments.database_file
         database = persistence.Database(path)
     except:
         logging.exception("could NOT connect to the database!")
@@ -234,9 +232,12 @@ def parse_cmdline_arguments() -> typing.Optional[argparse.Namespace]:
         "--database-file", type=str, default=default_database_dir,
         help="Path to database file (default: {})".format(default_database_dir)
     )
-
-    args = parser.parse_args(sys.argv[1:])
-    return args
+    parser.add_argument(
+        '-d', '--debug',
+        action="store_const", dest="loglevel", const=logging.DEBUG, default=logging.INFO,
+        help="Print debugging information in addition to normal processing.",
+    )
+    return parser.parse_args(sys.argv[1:])
 
 
 if __name__ == "__main__":

--- a/magneticod/magneticod/__main__.py
+++ b/magneticod/magneticod/__main__.py
@@ -67,8 +67,11 @@ def main():
 
     complete_info_hashes = database.get_complete_info_hashes()
 
-    node = dht.SybilNode(arguments.node_addr, max_metadata_size=arguments.metadata_size_limit)
-    node.when_peer_found = on_peer_found
+    node = dht.SybilNode(arguments.node_addr)
+
+    node.when_peer_found = lambda info_hash, peer_address: on_peer_found(info_hash=info_hash,
+                                                                         peer_address=peer_address,
+                                                                         max_metadata_size=arguments.max_metadata_size)
 
     selector.register(node, selectors.EVENT_READ)
 
@@ -223,8 +226,8 @@ def parse_cmdline_arguments() -> typing.Optional[argparse.Namespace]:
     )
 
     parser.add_argument(
-        "--metadata-size-limit", type=parse_size, default=DEFAULT_MAX_METADATA_SIZE,
-        help="Limit metadata size to protect memory overflow"
+        "--max-metadata-size", type=parse_size, default=DEFAULT_MAX_METADATA_SIZE,
+        help="Limit metadata size to protect memory overflow. Provide in human friendly format eg. 1 M, 1 GB"
     )
 
     default_database_dir = os.path.join(appdirs.user_data_dir("magneticod"), "database.sqlite3")

--- a/magneticod/magneticod/bittorrent.py
+++ b/magneticod/magneticod/bittorrent.py
@@ -22,6 +22,7 @@ import os
 
 from . import bencode
 
+MAX_METADATA_SIZE = 5*1024*1024
 
 InfoHash = bytes
 PeerAddress = typing.Tuple[str, int]
@@ -209,7 +210,8 @@ class DisposablePeer:
             # Just to make sure that the remote peer supports ut_metadata extension:
             ut_metadata = msg_dict[b"m"][b"ut_metadata"]
             metadata_size = msg_dict[b"metadata_size"]
-            assert metadata_size > 0
+            assert metadata_size > 0, "Invalid (empty) metada size"
+            assert metadata_size < MAX_METADATA_SIZE, "Malicious or malfunctioning peer tried send a huge metadata size"
         except (AssertionError, KeyError):
             self.when_error()
             return

--- a/magneticod/magneticod/bittorrent.py
+++ b/magneticod/magneticod/bittorrent.py
@@ -40,6 +40,7 @@ class DisposablePeer:
         if res != errno.EINPROGRESS:
             raise ConnectionError()
 
+        self.__peer_addr = peer_addr
         self.__info_hash = info_hash
 
         self.__max_metadata_size = max_metadata_size
@@ -211,10 +212,16 @@ class DisposablePeer:
             # Just to make sure that the remote peer supports ut_metadata extension:
             ut_metadata = msg_dict[b"m"][b"ut_metadata"]
             metadata_size = msg_dict[b"metadata_size"]
-            assert metadata_size > 0, "Invalid (empty) metada size"
-            assert metadata_size < self.__max_metadata_size, "Malicious or malfunctioning peer tried send above " \
-                                                             "{} limit metadata size".format(self.__max_metadata_size)
-        except (AssertionError, KeyError):
+            assert metadata_size > 0, "Invalid (empty) metadata size"
+            assert metadata_size < self.__max_metadata_size, "Malicious or malfunctioning peer {}:{} tried send above" \
+                                                             " {} max metadata size".format(self.__peer_addr[0],
+                                                                                            self.__peer_addr[1],
+                                                                                            self.__max_metadata_size)
+        except KeyError:
+            self.when_error()
+            return
+        except AssertionError as e:
+            logging.debug(str(e))
             self.when_error()
             return
 

--- a/magneticod/magneticod/constants.py
+++ b/magneticod/magneticod/constants.py
@@ -4,7 +4,7 @@ BOOTSTRAPPING_NODES = [
     ("router.bittorrent.com", 6881),
     ("dht.transmissionbt.com", 6881)
 ]
-PENDING_INFO_HASHES = 10
+PENDING_INFO_HASHES = 10  # threshold for pending info hashes before being committed to database:
 
 TICK_INTERVAL = 1  # in seconds (soft constraint)
  # maximum (inclusive) number of active (disposable) peers to fetch the metadata per info hash at the same time:

--- a/magneticod/magneticod/constants.py
+++ b/magneticod/magneticod/constants.py
@@ -1,0 +1,11 @@
+# coding=utf-8
+DEFAULT_MAX_METADATA_SIZE = 10 * 1024 * 1024
+BOOTSTRAPPING_NODES = [
+    ("router.bittorrent.com", 6881),
+    ("dht.transmissionbt.com", 6881)
+]
+PENDING_INFO_HASHES = 10
+
+TICK_INTERVAL = 1  # in seconds (soft constraint)
+ # maximum (inclusive) number of active (disposable) peers to fetch the metadata per info hash at the same time:
+MAX_ACTIVE_PEERS_PER_INFO_HASH = 5

--- a/magneticod/magneticod/dht.py
+++ b/magneticod/magneticod/dht.py
@@ -20,6 +20,7 @@ import socket
 import typing
 import os
 
+from .constants import BOOTSTRAPPING_NODES, DEFAULT_MAX_METADATA_SIZE
 from . import bencode
 
 NodeID = bytes
@@ -28,14 +29,8 @@ PeerAddress = typing.Tuple[str, int]
 InfoHash = bytes
 
 
-BOOTSTRAPPING_NODES = [
-    ("router.bittorrent.com", 6881),
-    ("dht.transmissionbt.com", 6881)
-]
-
-
 class SybilNode:
-    def __init__(self, address: typing.Tuple[str, int]):
+    def __init__(self, address: typing.Tuple[str, int], max_metadata_size: int=DEFAULT_MAX_METADATA_SIZE):
         self.__true_id = self.__random_bytes(20)
 
         self.__socket = socket.socket(type=socket.SOCK_DGRAM)
@@ -48,7 +43,7 @@ class SybilNode:
         self.__routing_table = {}  # type: typing.Dict[NodeID, NodeAddress]
 
         self.__token_secret = self.__random_bytes(4)
-
+        self.__max_metadata_size = max_metadata_size
         # Maximum number of neighbours (this is a THRESHOLD where, once reached, the search for new neighbours will
         # stop; but until then, the total number of neighbours might exceed the threshold).
         self.__n_max_neighbours = 2000
@@ -56,7 +51,8 @@ class SybilNode:
         logging.info("SybilNode %s on %s initialized!", self.__true_id.hex().upper(), address)
 
     @staticmethod
-    def when_peer_found(info_hash: InfoHash, peer_addr: PeerAddress) -> None:
+    def when_peer_found(info_hash: InfoHash, peer_addr: PeerAddress,
+                        max_metadata_size: int=DEFAULT_MAX_METADATA_SIZE) -> None:
         raise NotImplementedError()
 
     def on_tick(self) -> None:
@@ -208,7 +204,7 @@ class SybilNode:
         else:
             peer_addr = (addr[0], port)
 
-        self.when_peer_found(info_hash, peer_addr)
+        self.when_peer_found(info_hash, peer_addr, self.max_metadata_size)
 
     def fileno(self) -> int:
         return self.__socket.fileno()

--- a/magneticod/magneticod/dht.py
+++ b/magneticod/magneticod/dht.py
@@ -30,7 +30,7 @@ InfoHash = bytes
 
 
 class SybilNode:
-    def __init__(self, address: typing.Tuple[str, int], max_metadata_size: int=DEFAULT_MAX_METADATA_SIZE):
+    def __init__(self, address: typing.Tuple[str, int]):
         self.__true_id = self.__random_bytes(20)
 
         self.__socket = socket.socket(type=socket.SOCK_DGRAM)
@@ -43,7 +43,6 @@ class SybilNode:
         self.__routing_table = {}  # type: typing.Dict[NodeID, NodeAddress]
 
         self.__token_secret = self.__random_bytes(4)
-        self.__max_metadata_size = max_metadata_size
         # Maximum number of neighbours (this is a THRESHOLD where, once reached, the search for new neighbours will
         # stop; but until then, the total number of neighbours might exceed the threshold).
         self.__n_max_neighbours = 2000
@@ -51,8 +50,7 @@ class SybilNode:
         logging.info("SybilNode %s on %s initialized!", self.__true_id.hex().upper(), address)
 
     @staticmethod
-    def when_peer_found(info_hash: InfoHash, peer_addr: PeerAddress,
-                        max_metadata_size: int=DEFAULT_MAX_METADATA_SIZE) -> None:
+    def when_peer_found(info_hash: InfoHash, peer_addr: PeerAddress) -> None:
         raise NotImplementedError()
 
     def on_tick(self) -> None:
@@ -204,7 +202,7 @@ class SybilNode:
         else:
             peer_addr = (addr[0], port)
 
-        self.when_peer_found(info_hash, peer_addr, self.__max_metadata_size)
+        self.when_peer_found(info_hash, peer_addr)
 
     def fileno(self) -> int:
         return self.__socket.fileno()

--- a/magneticod/magneticod/dht.py
+++ b/magneticod/magneticod/dht.py
@@ -204,7 +204,7 @@ class SybilNode:
         else:
             peer_addr = (addr[0], port)
 
-        self.when_peer_found(info_hash, peer_addr, self.max_metadata_size)
+        self.when_peer_found(info_hash, peer_addr, self.__max_metadata_size)
 
     def fileno(self) -> int:
         return self.__socket.fileno()

--- a/magneticod/magneticod/persistence.py
+++ b/magneticod/magneticod/persistence.py
@@ -18,6 +18,8 @@ import time
 import typing
 import os
 
+from magneticod import bencode
+
 from .constants import PENDING_INFO_HASHES
 
 

--- a/magneticod/magneticod/persistence.py
+++ b/magneticod/magneticod/persistence.py
@@ -18,11 +18,9 @@ import time
 import typing
 import os
 
-from . import bencode
-
-
 # threshold for pending info hashes before being committed to database:
-PENDING_INFO_HASHES = 10
+
+from .constants import PENDING_INFO_HASHES
 
 
 class Database:

--- a/magneticod/magneticod/persistence.py
+++ b/magneticod/magneticod/persistence.py
@@ -18,8 +18,6 @@ import time
 import typing
 import os
 
-# threshold for pending info hashes before being committed to database:
-
 from .constants import PENDING_INFO_HASHES
 
 

--- a/magneticod/setup.py
+++ b/magneticod/setup.py
@@ -23,7 +23,8 @@ setup(
 
     install_requires=[
         "appdirs >= 1.4.3",
-        "bencoder.pyx >= 1.1.3"
+        "bencoder.pyx >= 1.1.3",
+        "humanfriendly"
     ],
 
     classifiers=[


### PR DESCRIPTION
Malicious or malfunctioning peer can try send a huge metadata size what causes huge memory usage and to overflow them.

I believe ```5*1024*1024``` bytes (5 MB) is appropriate value. I collect some data about metadatas in the wild. 

```
$ cat sizes.txt  | sort -n -r | head -n 25
2038487152
2024076552
4240870
1613834
1506524
1464631
1095764
1074151
1030241
1030241
836313
737149
667923
650744
635983
627184
566177
525960
507896
480910
465131
454008
448114
437954
421390
```
I believe top 2 metadata sizes (>2 GB) is malicious. I reject them from the calculations. The remaining metadata sizes have been calculated basic statistical indicators.

```
mean(field-1): 33562,626346568
q1(field-1): 13214,75
median(field-1): 17090,5
q3(field-1): 28592
sstdev(field-1): 82416,699847084
min(field-1): 91
max(field-1): 4240870
count(field-1): 6498
```

It fixes #57. 
I think 5 MB of metadata size is a safe value. Alternatively, some intelligent calibration mechanisms may be introduced to discard extremely different values. For example, calculate the average size and reject the multiple of the mean.