### PR TITLE
Flush metadata buffer when exiting gracefully

### DIFF
--- a/magneticod/magneticod/persistence.py
+++ b/magneticod/magneticod/persistence.py
@@ -131,4 +131,6 @@ class Database:
             cur.close()
 
     def close(self) -> None:
+        if self.__pending_metadata:
+            self.__commit_metadata()
         self.__db_conn.close()


### PR DESCRIPTION
Hello,

I think this is good to store all collected metadata when exiting gracefully without waiting to collect 10 (it will never happend).

Greetings,