### PR TITLE
Asyncio rewrite of magneticod

### DIFF
--- a/magneticod/magneticod/__main__.py
+++ b/magneticod/magneticod/__main__.py
@@ -57,10 +57,9 @@ def main():
         loop.run_forever()
     except KeyboardInterrupt:
         logging.critical("Keyboard interrupt received! Exiting gracefully...")
-        pass
     finally:
         database.close()
-        node.shutdown()
+        loop.run_until_complete(node.shutdown())
 
     return 0
 

--- a/magneticod/magneticod/__main__.py
+++ b/magneticod/magneticod/__main__.py
@@ -37,6 +37,14 @@ def main():
     logging.basicConfig(level=arguments.loglevel, format="%(asctime)s  %(levelname)-8s  %(message)s")
     logging.info("magneticod v%d.%d.%d started", *__version__)
 
+    # use uvloop if it's installed
+    try:
+        import uvloop
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+        logging.info("using uvloop")
+    except ModuleNotFoundError:
+        pass
+
     # noinspection PyBroadException
     try:
         path = arguments.database_file

--- a/magneticod/magneticod/__main__.py
+++ b/magneticod/magneticod/__main__.py
@@ -42,7 +42,7 @@ def main():
         import uvloop
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
         logging.info("using uvloop")
-    except ModuleNotFoundError:
+    except ImportError:
         pass
 
     # noinspection PyBroadException

--- a/magneticod/magneticod/__main__.py
+++ b/magneticod/magneticod/__main__.py
@@ -56,7 +56,7 @@ def create_tasks():
     complete_info_hashes = database.get_complete_info_hashes()
 
     loop = asyncio.get_event_loop()
-    node = dht.SybilNode(arguments.node_addr, complete_info_hashes, arguments.max_metadata_size)
+    node = dht.SybilNode(arguments.node_addr, database.is_infohash_new, arguments.max_metadata_size)
     loop.create_task(node.launch(loop))
     watch_q_task = loop.create_task(watch_q(database, node.metadata_q()))
     watch_q_task.add_done_callback(lambda x: clean_up(loop, database, node))

--- a/magneticod/magneticod/__main__.py
+++ b/magneticod/magneticod/__main__.py
@@ -61,7 +61,7 @@ def main():
         database.close()
         watch_q_task.cancel()
         loop.run_until_complete(node.shutdown())
-        loop.run_until_complete(watch_q_task)
+        loop.run_until_complete(asyncio.wait([watch_q_task]))
 
     return 0
 

--- a/magneticod/magneticod/__main__.py
+++ b/magneticod/magneticod/__main__.py
@@ -13,45 +13,25 @@
 # You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
 # <http://www.gnu.org/licenses/>.
 import argparse
-import collections
-import functools
+import asyncio
 import logging
 import ipaddress
-import selectors
 import textwrap
 import urllib.parse
-import itertools
 import os
 import sys
-import time
 import typing
 
 import appdirs
 import humanfriendly
 
-from .constants import TICK_INTERVAL, MAX_ACTIVE_PEERS_PER_INFO_HASH, DEFAULT_MAX_METADATA_SIZE
+from .constants import DEFAULT_MAX_METADATA_SIZE
 from . import __version__
-from . import bittorrent
 from . import dht
 from . import persistence
 
 
-# Global variables are bad bla bla bla, BUT these variables are used so many times that I think it is justified; else
-# the signatures of many functions are literally cluttered.
-#
-# If you are using a global variable, please always indicate that at the VERY BEGINNING of the function instead of right
-# before using the variable for the first time.
-selector = selectors.DefaultSelector()
-database = None  # type: persistence.Database
-node = None
-peers = collections.defaultdict(list)  # type: typing.DefaultDict[dht.InfoHash, typing.List[bittorrent.DisposablePeer]]
-# info hashes whose metadata is valid & complete (OR complete but deemed to be corrupt) so do NOT download them again:
-complete_info_hashes = set()
-
-
 def main():
-    global complete_info_hashes, database, node, peers, selector
-
     arguments = parse_cmdline_arguments()
 
     logging.basicConfig(level=arguments.loglevel, format="%(asctime)s  %(levelname)-8s  %(message)s")
@@ -67,106 +47,30 @@ def main():
 
     complete_info_hashes = database.get_complete_info_hashes()
 
-    node = dht.SybilNode(arguments.node_addr)
+    loop = asyncio.get_event_loop()
+    node = dht.SybilNode(arguments.node_addr, complete_info_hashes, arguments.max_metadata_size)
+    loop.run_until_complete(node.launch(loop))
 
-    node.when_peer_found = lambda info_hash, peer_address: on_peer_found(info_hash=info_hash,
-                                                                         peer_address=peer_address,
-                                                                         max_metadata_size=arguments.max_metadata_size)
-
-    selector.register(node, selectors.EVENT_READ)
+    loop.create_task(watch_q(database, node._metadata_q))
 
     try:
-        loop()
+        loop.run_forever()
     except KeyboardInterrupt:
         logging.critical("Keyboard interrupt received! Exiting gracefully...")
         pass
     finally:
         database.close()
-        selector.close()
         node.shutdown()
-        for peer in itertools.chain.from_iterable(peers.values()):
-            peer.shutdown()
 
     return 0
 
 
-def on_peer_found(info_hash: dht.InfoHash, peer_address, max_metadata_size: int=DEFAULT_MAX_METADATA_SIZE) -> None:
-    global selector, peers, complete_info_hashes
-
-    if len(peers[info_hash]) > MAX_ACTIVE_PEERS_PER_INFO_HASH or info_hash in complete_info_hashes:
-        return
-
-    try:
-        peer = bittorrent.DisposablePeer(info_hash, peer_address, max_metadata_size)
-    except ConnectionError:
-        return
-
-    selector.register(peer, selectors.EVENT_READ | selectors.EVENT_WRITE)
-    peer.when_metadata_found = on_metadata_found
-    peer.when_error = functools.partial(on_peer_error, peer, info_hash)
-    peers[info_hash].append(peer)
-
-
-def on_metadata_found(info_hash: dht.InfoHash, metadata: bytes) -> None:
-    global complete_info_hashes, database, peers, selector
-
-    succeeded = database.add_metadata(info_hash, metadata)
-    if not succeeded:
-        logging.info("Corrupt metadata for %s! Ignoring.", info_hash.hex())
-
-    # When we fetch the metadata of an info hash completely, shut down all other peers who are trying to do the same.
-    for peer in peers[info_hash]:
-        selector.unregister(peer)
-        peer.shutdown()
-    del peers[info_hash]
-
-    complete_info_hashes.add(info_hash)
-
-
-def on_peer_error(peer: bittorrent.DisposablePeer, info_hash: dht.InfoHash) -> None:
-    global peers, selector
-    peer.shutdown()
-    peers[info_hash].remove(peer)
-    selector.unregister(peer)
-
-
-# TODO:
-# Consider whether time.monotonic() is a good choice. Maybe we should use CLOCK_MONOTONIC_RAW as its not affected by NTP
-# adjustments, and all we need is how many seconds passed since a certain point in time.
-def loop() -> None:
-    global selector, node, peers
-
-    t0 = time.monotonic()
+async def watch_q(database, q):
     while True:
-        keys_and_events = selector.select(timeout=TICK_INTERVAL)
-
-        # Check if it is time to tick
-        delta = time.monotonic() - t0
-        if delta >= TICK_INTERVAL:
-            if not (delta < 2 * TICK_INTERVAL):
-                logging.warning("Belated TICK! (Δ = %d)", delta)
-
-            node.on_tick()
-            for peer_list in peers.values():
-                for peer in peer_list:
-                    peer.on_tick()
-
-            t0 = time.monotonic()
-
-        for key, events in keys_and_events:
-            if events & selectors.EVENT_READ:
-                key.fileobj.on_receivable()
-            if events & selectors.EVENT_WRITE:
-                key.fileobj.on_sendable()
-
-        # Check for entities that would like to write to their socket
-        keymap = selector.get_map()
-        for fd in keymap:
-            fileobj = keymap[fd].fileobj
-            if fileobj.would_send():
-                selector.modify(fileobj, selectors.EVENT_READ | selectors.EVENT_WRITE)
-            else:
-                selector.modify(fileobj, selectors.EVENT_READ)
+        info_hash, metadata = await q.get()
+        succeeded = database.add_metadata(info_hash, metadata)
+        if not succeeded:
+            logging.info("Corrupt metadata for %s! Ignoring.", info_hash.hex())
 
 
 def parse_ip_port(netloc) -> typing.Optional[typing.Tuple[str, int]]:

--- a/magneticod/magneticod/__main__.py
+++ b/magneticod/magneticod/__main__.py
@@ -51,7 +51,7 @@ def main():
     node = dht.SybilNode(arguments.node_addr, complete_info_hashes, arguments.max_metadata_size)
     loop.run_until_complete(node.launch(loop))
 
-    loop.create_task(watch_q(database, node._metadata_q))
+    watch_q_task = loop.create_task(watch_q(database, node._metadata_q))
 
     try:
         loop.run_forever()
@@ -59,7 +59,9 @@ def main():
         logging.critical("Keyboard interrupt received! Exiting gracefully...")
     finally:
         database.close()
+        watch_q_task.cancel()
         loop.run_until_complete(node.shutdown())
+        loop.run_until_complete(watch_q_task)
 
     return 0
 

--- a/magneticod/magneticod/__main__.py
+++ b/magneticod/magneticod/__main__.py
@@ -31,8 +31,8 @@ from . import dht
 from . import persistence
 
 
-def main():
-    arguments = parse_cmdline_arguments()
+def create_tasks():
+    arguments = parse_cmdline_arguments(sys.argv[1:])
 
     logging.basicConfig(level=arguments.loglevel, format="%(asctime)s  %(levelname)-8s  %(message)s")
     logging.info("magneticod v%d.%d.%d started", *__version__)
@@ -57,21 +57,15 @@ def main():
 
     loop = asyncio.get_event_loop()
     node = dht.SybilNode(arguments.node_addr, complete_info_hashes, arguments.max_metadata_size)
-    loop.run_until_complete(node.launch(loop))
+    loop.create_task(node.launch(loop))
+    watch_q_task = loop.create_task(watch_q(database, node.metadata_q()))
+    watch_q_task.add_done_callback(lambda x: clean_up(loop, database, node))
+    return watch_q_task
 
-    watch_q_task = loop.create_task(watch_q(database, node._metadata_q))
 
-    try:
-        loop.run_forever()
-    except KeyboardInterrupt:
-        logging.critical("Keyboard interrupt received! Exiting gracefully...")
-    finally:
-        database.close()
-        watch_q_task.cancel()
-        loop.run_until_complete(node.shutdown())
-        loop.run_until_complete(asyncio.wait([watch_q_task]))
-
-    return 0
+def clean_up(loop, database, node):
+    database.close()
+    loop.run_until_complete(node.shutdown())
 
 
 async def watch_q(database, q):
@@ -109,7 +103,7 @@ def parse_size(value: str) -> int:
         raise argparse.ArgumentTypeError("Invalid argument. {}".format(e))
 
 
-def parse_cmdline_arguments() -> typing.Optional[argparse.Namespace]:
+def parse_cmdline_arguments(args) -> typing.Optional[argparse.Namespace]:
     parser = argparse.ArgumentParser(
         description="Autonomous BitTorrent DHT crawler and metadata fetcher.",
         epilog=textwrap.dedent("""\
@@ -153,7 +147,19 @@ def parse_cmdline_arguments() -> typing.Optional[argparse.Namespace]:
         action="store_const", dest="loglevel", const=logging.DEBUG, default=logging.INFO,
         help="Print debugging information in addition to normal processing.",
     )
-    return parser.parse_args(sys.argv[1:])
+    return parser.parse_args(args)
+
+
+def main():
+    main_task = create_tasks()
+    try:
+        asyncio.get_event_loop().run_forever()
+    except KeyboardInterrupt:
+        logging.critical("Keyboard interrupt received! Exiting gracefully...")
+    finally:
+        main_task.cancel()
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/magneticod/magneticod/bittorrent.py
+++ b/magneticod/magneticod/bittorrent.py
@@ -26,15 +26,10 @@ PeerAddress = typing.Tuple[str, int]
 
 
 async def fetch_metadata(info_hash: InfoHash, peer_addr: PeerAddress, max_metadata_size, timeout=None):
-    loop = asyncio.get_event_loop()
-    task = asyncio.ensure_future(DisposablePeer().run(
-        asyncio.get_event_loop(), info_hash, peer_addr, max_metadata_size))
-    h = None
-    if timeout is not None:
-        h = loop.call_later(timeout, lambda: task.cancel())
     try:
-        return await task
-    except asyncio.CancelledError:
+        return await asyncio.wait_for(DisposablePeer().run(
+            asyncio.get_event_loop(), info_hash, peer_addr, max_metadata_size), timeout=timeout)
+    except asyncio.TimeoutError:
         return None
 
 

--- a/magneticod/magneticod/bittorrent.py
+++ b/magneticod/magneticod/bittorrent.py
@@ -81,7 +81,7 @@ class DisposablePeer:
                 message = await self._reader.readexactly(length)
                 self.__on_message(message)
         except Exception as ex:
-            logging.info("closing %s to %s", self.__info_hash.hex(), self.__peer_addr)
+            logging.debug("closing %s to %s", self.__info_hash.hex(), self.__peer_addr)
             if not self._metadata_future.done():
                 self._metadata_future.set_result(None)
         if self._writer:

--- a/magneticod/magneticod/bittorrent.py
+++ b/magneticod/magneticod/bittorrent.py
@@ -52,7 +52,6 @@ class DisposablePeer:
 
         self._metadata_future = loop.create_future()
         self._writer = None
-        self._is_paused = False
 
         try:
             self._reader, self._writer = await asyncio.open_connection(
@@ -88,12 +87,6 @@ class DisposablePeer:
         if self._writer:
             self._writer.close()
         return self._metadata_future.result()
-
-    def pause_writing(self):
-        self._is_paused = True
-
-    def resume_writing(self):
-        self._is_paused = False
 
     def __on_message(self, message: bytes) -> None:
         length = len(message)

--- a/magneticod/magneticod/bittorrent.py
+++ b/magneticod/magneticod/bittorrent.py
@@ -20,7 +20,6 @@ import typing
 import os
 
 from . import bencode
-from .constants import DEFAULT_MAX_METADATA_SIZE
 
 InfoHash = bytes
 PeerAddress = typing.Tuple[str, int]
@@ -36,8 +35,7 @@ class ProtocolError(Exception):
 
 
 class DisposablePeer:
-    async def run(self, loop, info_hash: InfoHash, peer_addr: PeerAddress,
-                  max_metadata_size: int=DEFAULT_MAX_METADATA_SIZE):
+    async def run(self, loop, info_hash: InfoHash, peer_addr: PeerAddress, max_metadata_size: int):
         self.__peer_addr = peer_addr
         self.__info_hash = info_hash
 

--- a/magneticod/magneticod/bittorrent.py
+++ b/magneticod/magneticod/bittorrent.py
@@ -52,6 +52,7 @@ class DisposablePeer:
 
         self._metadata_future = loop.create_future()
         self._writer = None
+        self._is_paused = False
 
         try:
             self._reader, self._writer = await asyncio.open_connection(
@@ -87,6 +88,12 @@ class DisposablePeer:
         if self._writer:
             self._writer.close()
         return self._metadata_future.result()
+
+    def pause_writing(self):
+        self._is_paused = True
+
+    def resume_writing(self):
+        self._is_paused = False
 
     def __on_message(self, message: bytes) -> None:
         length = len(message)

--- a/magneticod/magneticod/bittorrent.py
+++ b/magneticod/magneticod/bittorrent.py
@@ -26,7 +26,7 @@ InfoHash = bytes
 PeerAddress = typing.Tuple[str, int]
 
 
-async def get_torrent_data(info_hash: InfoHash, peer_addr: PeerAddress, max_metadata_size):
+async def fetch_metadata(info_hash: InfoHash, peer_addr: PeerAddress, max_metadata_size):
     loop = asyncio.get_event_loop()
     peer = DisposablePeer(info_hash, peer_addr, max_metadata_size)
     r = await peer.launch(loop)

--- a/magneticod/magneticod/constants.py
+++ b/magneticod/magneticod/constants.py
@@ -6,8 +6,7 @@ BOOTSTRAPPING_NODES = [
 ]
 PENDING_INFO_HASHES = 10  # threshold for pending info hashes before being committed to database:
 
-TICK_INTERVAL = 1  # in seconds (soft constraint)
  # maximum (inclusive) number of active (disposable) peers to fetch the metadata per info hash at the same time:
 MAX_ACTIVE_PEERS_PER_INFO_HASH = 5
 
-PEER_TIMEOUT=12 # seconds
+PEER_TIMEOUT=120 # seconds

--- a/magneticod/magneticod/constants.py
+++ b/magneticod/magneticod/constants.py
@@ -9,3 +9,5 @@ PENDING_INFO_HASHES = 10  # threshold for pending info hashes before being commi
 TICK_INTERVAL = 1  # in seconds (soft constraint)
  # maximum (inclusive) number of active (disposable) peers to fetch the metadata per info hash at the same time:
 MAX_ACTIVE_PEERS_PER_INFO_HASH = 5
+
+PEER_TIMEOUT=12 # seconds

--- a/magneticod/magneticod/dht.py
+++ b/magneticod/magneticod/dht.py
@@ -62,6 +62,9 @@ class SybilNode:
         self._tasks.append(self._loop.create_task(self.increase_neighbour_task()))
         self._transport = transport
 
+    def connection_lost(self, exc):
+        self._is_paused = True
+
     def pause_writing(self):
         self._is_paused = True
 

--- a/magneticod/magneticod/dht.py
+++ b/magneticod/magneticod/dht.py
@@ -13,15 +13,18 @@
 # You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
 # <http://www.gnu.org/licenses/>.
 import array
+import asyncio
 import collections
+import itertools
 import zlib
 import logging
 import socket
 import typing
 import os
 
-from .constants import BOOTSTRAPPING_NODES, DEFAULT_MAX_METADATA_SIZE
+from .constants import BOOTSTRAPPING_NODES, DEFAULT_MAX_METADATA_SIZE, MAX_ACTIVE_PEERS_PER_INFO_HASH
 from . import bencode
+from . import bittorrent
 
 NodeID = bytes
 NodeAddress = typing.Tuple[str, int]
@@ -30,107 +33,77 @@ InfoHash = bytes
 
 
 class SybilNode:
-    def __init__(self, address: typing.Tuple[str, int]):
+    def __init__(self, address: typing.Tuple[str, int], complete_info_hashes, max_metadata_size):
         self.__true_id = self.__random_bytes(20)
 
-        self.__socket = socket.socket(type=socket.SOCK_DGRAM)
-        self.__socket.bind(address)
-        self.__socket.setblocking(False)
+        self.__address = address
 
-        self.__incoming_buffer = array.array("B", (0 for _ in range(65536)))
-        self.__outgoing_queue = collections.deque()
-
-        self.__routing_table = {}  # type: typing.Dict[NodeID, NodeAddress]
+        self._routing_table = {}  # type: typing.Dict[NodeID, NodeAddress]
 
         self.__token_secret = self.__random_bytes(4)
         # Maximum number of neighbours (this is a THRESHOLD where, once reached, the search for new neighbours will
         # stop; but until then, the total number of neighbours might exceed the threshold).
         self.__n_max_neighbours = 2000
+        self.__peers = collections.defaultdict(
+            list)  # type: typing.DefaultDict[dht.InfoHash, typing.List[bittorrent.DisposablePeer]]
+        self._complete_info_hashes = complete_info_hashes
+        self.__max_metadata_size = max_metadata_size
+        self._metadata_q = asyncio.Queue()
 
         logging.info("SybilNode %s on %s initialized!", self.__true_id.hex().upper(), address)
 
-    @staticmethod
-    def when_peer_found(info_hash: InfoHash, peer_addr: PeerAddress) -> None:
-        raise NotImplementedError()
+    async def launch(self, loop):
+        self._loop = loop
+        await loop.create_datagram_endpoint(lambda: self, local_addr=self.__address)
 
-    def on_tick(self) -> None:
-        self.__bootstrap()
-        self.__make_neighbours()
-        self.__routing_table.clear()
+    def connection_made(self, transport):
+        self._loop.create_task(self.on_tick())
+        self._loop.create_task(self.increase_neighbour_task())
+        self._transport = transport
 
-    def on_receivable(self) -> None:
-        buffer = self.__incoming_buffer
-        while True:
-            try:
-                _, addr = self.__socket.recvfrom_into(buffer, 65536)
-                data = buffer.tobytes()
-            except BlockingIOError:
-                break
-            except ConnectionResetError:
-                continue
-            except ConnectionRefusedError:
-                continue
-
-            # Ignore nodes that uses port 0 (assholes).
-            if addr[1] == 0:
-                continue
-
-            try:
-                message = bencode.loads(data)
-            except bencode.BencodeDecodingError:
-                continue
-
-            if isinstance(message.get(b"r"), dict) and type(message[b"r"].get(b"nodes")) is bytes:
-                self.__on_FIND_NODE_response(message)
-            elif message.get(b"q") == b"get_peers":
-                self.__on_GET_PEERS_query(message, addr)
-            elif message.get(b"q") == b"announce_peer":
-                self.__on_ANNOUNCE_PEER_query(message, addr)
-
-    def on_sendable(self) -> None:
-        congestion = None
-        while True:
-            try:
-                addr, data = self.__outgoing_queue.pop()
-            except IndexError:
-                break
-
-            try:
-                self.__socket.sendto(data, addr)
-            except BlockingIOError:
-                self.__outgoing_queue.appendleft((addr, data))
-                break
-            except PermissionError:
-                # This exception (EPERM errno: 1) is kernel's way of saying that "you are far too fast, chill".
-                # It is also likely that we have received a ICMP source quench packet (meaning, that we really need to
-                # slow down.
-                #
-                # Read more here: http://www.archivum.info/comp.protocols.tcp-ip/2009-05/00088/UDP-socket-amp-amp-sendto
-                # -amp-amp-EPERM.html
-                congestion = True
-                break
-            except OSError:
-                # Pass in case of trying to send to port 0 (it is much faster to catch exceptions than using an
-                # if-statement).
-                pass
-
-        if congestion:
-            self.__outgoing_queue.clear()
+    def error_received(self, exc):
+        logging.error("got error %s", exc)
+        if isinstance(exc, PermissionError):
             # In case of congestion, decrease the maximum number of nodes to the 90% of the current value.
             if self.__n_max_neighbours < 200:
                 logging.warning("Maximum number of neighbours are now less than 200 due to congestion!")
             else:
                 self.__n_max_neighbours = self.__n_max_neighbours * 9 // 10
-        else:
-            # In case of the lack of congestion, increase the maximum number of nodes by 1%.
+                logging.debug("Maximum number of neighbours now %d", self.__n_max_neighbours)
+
+    async def on_tick(self) -> None:
+        while True:
+            await asyncio.sleep(1)
+            self.__bootstrap()
+            self.__make_neighbours()
+            self._routing_table.clear()
+
+    def datagram_received(self, data, addr) -> None:
+        # Ignore nodes that uses port 0 (assholes).
+        if addr[1] == 0:
+            return
+
+        try:
+            message = bencode.loads(data)
+        except bencode.BencodeDecodingError:
+            return
+
+        if isinstance(message.get(b"r"), dict) and type(message[b"r"].get(b"nodes")) is bytes:
+            self.__on_FIND_NODE_response(message)
+        elif message.get(b"q") == b"get_peers":
+            self.__on_GET_PEERS_query(message, addr)
+        elif message.get(b"q") == b"announce_peer":
+            self.__on_ANNOUNCE_PEER_query(message, addr)
+
+    async def increase_neighbour_task(self):
+        while True:
+            await asyncio.sleep(10)
             self.__n_max_neighbours = self.__n_max_neighbours * 101 // 100
 
-    def would_send(self) -> bool:
-        """ Whether node is waiting to write on its socket or not. """
-        return bool(self.__outgoing_queue)
-
     def shutdown(self) -> None:
-        self.__socket.close()
+        for peer in itertools.chain.from_iterable(self.__peers.values()):
+            peer.close()
+        self._transport.close()
 
     def __on_FIND_NODE_response(self, message: bencode.KRPCDict) -> None:
         try:
@@ -145,8 +118,8 @@ class SybilNode:
             return
 
         # Add new found nodes to the routing table, assuring that we have no more than n_max_neighbours in total.
-        if len(self.__routing_table) < self.__n_max_neighbours:
-            self.__routing_table.update(nodes)
+        if len(self._routing_table) < self.__n_max_neighbours:
+            self._routing_table.update(nodes)
 
     def __on_GET_PEERS_query(self, message: bencode.KRPCDict, addr: NodeAddress) -> None:
         try:
@@ -157,8 +130,7 @@ class SybilNode:
         except (TypeError, KeyError, AssertionError):
             return
 
-        # appendleft to prioritise GET_PEERS responses as they are the most fruitful ones!
-        self.__outgoing_queue.appendleft((addr, bencode.dumps({
+        data = bencode.dumps({
             b"y": b"r",
             b"t": transaction_id,
             b"r": {
@@ -166,7 +138,10 @@ class SybilNode:
                 b"nodes": b"",
                 b"token": self.__calculate_token(addr, info_hash)
             }
-        })))
+        })
+        # we want to prioritise GET_PEERS responses as they are the most fruitful ones!
+        # but there is no easy way to do this with asyncio
+        self._transport.sendto(data, addr)
 
     def __on_ANNOUNCE_PEER_query(self, message: bencode.KRPCDict, addr: NodeAddress) -> None:
         try:
@@ -189,31 +164,45 @@ class SybilNode:
         except (TypeError, KeyError, AssertionError):
             return
 
-        self.__outgoing_queue.append((addr, bencode.dumps({
+        data = bencode.dumps({
             b"y": b"r",
             b"t": transaction_id,
             b"r": {
                 b"id": node_id[:15] + self.__true_id[:5]
             }
-        })))
+        })
+        self._transport.sendto(data, addr)
 
         if implied_port:
             peer_addr = (addr[0], addr[1])
         else:
             peer_addr = (addr[0], port)
 
-        self.when_peer_found(info_hash, peer_addr)
+        if len(self.__peers[info_hash]) > MAX_ACTIVE_PEERS_PER_INFO_HASH or \
+           info_hash in self._complete_info_hashes:
+            return
 
-    def fileno(self) -> int:
-        return self.__socket.fileno()
+        peer = bittorrent.get_torrent_data(info_hash, peer_addr, self.__max_metadata_size)
+        self.__peers[info_hash].append(peer)
+        self._loop.create_task(peer).add_done_callback(self.metadata_found)
+
+    def metadata_found(self, future):
+        r = future.result()
+        if r:
+            info_hash, metadata = r
+            for peer in self.__peers[info_hash]:
+                peer.close()
+        self._metadata_q.put_nowait(r)
+        self._complete_info_hashes.add(info_hash)
 
     def __bootstrap(self) -> None:
         for addr in BOOTSTRAPPING_NODES:
-            self.__outgoing_queue.append((addr, self.__build_FIND_NODE_query(self.__true_id)))
+            data = self.__build_FIND_NODE_query(self.__true_id)
+            self._transport.sendto(data, addr)
 
     def __make_neighbours(self) -> None:
-        for node_id, addr in self.__routing_table.items():
-            self.__outgoing_queue.append((addr, self.__build_FIND_NODE_query(node_id[:15] + self.__true_id[:5])))
+        for node_id, addr in self._routing_table.items():
+            self._transport.sendto(self.__build_FIND_NODE_query(node_id[:15] + self.__true_id[:5]), addr)
 
     @staticmethod
     def __decode_nodes(infos: bytes) -> typing.List[typing.Tuple[NodeID, NodeAddress]]:

--- a/magneticod/magneticod/dht.py
+++ b/magneticod/magneticod/dht.py
@@ -31,7 +31,7 @@ InfoHash = bytes
 
 
 class SybilNode:
-    def __init__(self, address: typing.Tuple[str, int], complete_info_hashes, max_metadata_size):
+    def __init__(self, address: typing.Tuple[str, int], is_infohash_new, max_metadata_size):
         self.__true_id = self.__random_bytes(20)
 
         self.__address = address
@@ -43,7 +43,7 @@ class SybilNode:
         # stop; but until then, the total number of neighbours might exceed the threshold).
         self.__n_max_neighbours = 2000
         self.__tasks = {}  # type: typing.Dict[dht.InfoHash, asyncio.Future]
-        self._complete_info_hashes = complete_info_hashes
+        self._is_inforhash_new = is_infohash_new
         self.__max_metadata_size = max_metadata_size
         self._metadata_q = asyncio.Queue()
         self._is_paused = False
@@ -200,7 +200,7 @@ class SybilNode:
         else:
             peer_addr = (addr[0], port)
 
-        if info_hash in self._complete_info_hashes:
+        if not self._is_inforhash_new(info_hash):
             return
 
         # create the parent future
@@ -240,7 +240,6 @@ class SybilNode:
         try:
             metadata = parent_task.result()
             if metadata:
-                self._complete_info_hashes.add(info_hash)
                 self._metadata_q.put_nowait((info_hash, metadata))
         except asyncio.CancelledError:
             pass

--- a/magneticod/magneticod/dht.py
+++ b/magneticod/magneticod/dht.py
@@ -84,6 +84,9 @@ class SybilNode:
         if addr[1] == 0:
             return
 
+        if self._transport.is_closing():
+            return
+
         try:
             message = bencode.loads(data)
         except bencode.BencodeDecodingError:

--- a/magneticod/magneticod/dht.py
+++ b/magneticod/magneticod/dht.py
@@ -192,8 +192,8 @@ class SybilNode:
             info_hash, metadata = r
             for peer in self.__peers[info_hash]:
                 peer.close()
-        self._metadata_q.put_nowait(r)
-        self._complete_info_hashes.add(info_hash)
+            self._metadata_q.put_nowait(r)
+            self._complete_info_hashes.add(info_hash)
 
     def __bootstrap(self) -> None:
         for addr in BOOTSTRAPPING_NODES:

--- a/magneticod/magneticod/dht.py
+++ b/magneticod/magneticod/dht.py
@@ -105,15 +105,11 @@ class SybilNode:
             self.__n_max_neighbours = self.__n_max_neighbours * 101 // 100
 
     async def shutdown(self) -> None:
-        peers = [peer for peer in itertools.chain.from_iterable(self.__peers.values())]
-        for peer in peers:
-            peer.cancel()
-        for peer in peers:
-            await peer
-        for task in self._tasks:
-            task.cancel()
-        for task in self._tasks:
-            await task
+        futures = [peer for peer in itertools.chain.from_iterable(self.__peers.values())]
+        futures.extend(self._tasks)
+        for future in futures:
+            future.cancel()
+        await asyncio.wait(futures)
         self._transport.close()
 
     def __on_FIND_NODE_response(self, message: bencode.KRPCDict) -> None:

--- a/magneticod/magneticod/dht.py
+++ b/magneticod/magneticod/dht.py
@@ -92,6 +92,9 @@ class SybilNode:
             self._routing_table.clear()
             if not self._is_paused:
                 self.__n_max_neighbours = self.__n_max_neighbours * 101 // 100
+            logging.debug("fetch metadata task count: %d", sum(
+                x.child_count for x in self.__tasks.values()))
+            logging.debug("asyncio task count: %d", len(asyncio.Task.all_tasks()))
 
     def datagram_received(self, data, addr) -> None:
         # Ignore nodes that uses port 0 (assholes).

--- a/magneticod/magneticod/dht.py
+++ b/magneticod/magneticod/dht.py
@@ -51,6 +51,9 @@ class SybilNode:
 
         logging.info("SybilNode %s on %s initialized!", self.__true_id.hex().upper(), address)
 
+    def metadata_q(self):
+        return self._metadata_q
+
     async def launch(self, loop):
         self._loop = loop
         await loop.create_datagram_endpoint(lambda: self, local_addr=self.__address)

--- a/magneticod/magneticod/dht.py
+++ b/magneticod/magneticod/dht.py
@@ -182,7 +182,7 @@ class SybilNode:
            info_hash in self._complete_info_hashes:
             return
 
-        peer = bittorrent.get_torrent_data(info_hash, peer_addr, self.__max_metadata_size)
+        peer = bittorrent.fetch_metadata(info_hash, peer_addr, self.__max_metadata_size)
         self.__peers[info_hash].append(peer)
         self._loop.create_task(peer).add_done_callback(self.metadata_found)
 

--- a/magneticod/magneticod/persistence.py
+++ b/magneticod/magneticod/persistence.py
@@ -94,11 +94,14 @@ class Database:
 
         return True
 
-    def get_complete_info_hashes(self) -> typing.Set[bytes]:
+    def is_infohash_new(self, info_hash):
+        if info_hash in [x[0] for x in self.__pending_metadata]:
+            return False
         cur = self.__db_conn.cursor()
         try:
-            cur.execute("SELECT info_hash FROM torrents;")
-            return set(x[0] for x in cur.fetchall())
+            cur.execute("SELECT count(info_hash) FROM torrents where info_hash = ?;", [info_hash])
+            x, = cur.fetchone()
+            return x == 0
         finally:
             cur.close()
 


### PR DESCRIPTION
I've rewritten and simplified much of magneticod to use asyncio.

This is a big change, so I can understand if you're reluctant to merge it. If you have requests about specific stylistic or other changes, I'm happy to work with you.

I've tested it in a Digital Ocean droplet, and it got 700 hashes in 30 minutes, about the same as v0.3.0. It seems to be a bit lighter on CPU.

The code is smaller by over 100 lines, and all the globals in __main__ are now gone.