### PR TITLE
Avoid __outgoing_queue increase to fill up memory

### DIFF
--- a/magneticod/magneticod/dht.py
+++ b/magneticod/magneticod/dht.py
@@ -28,7 +28,6 @@ NodeAddress = typing.Tuple[str, int]
 PeerAddress = typing.Tuple[str, int]
 InfoHash = bytes
 
-
 class SybilNode:
     def __init__(self, address: typing.Tuple[str, int]):
         self.__true_id = self.__random_bytes(20)
@@ -38,7 +37,7 @@ class SybilNode:
         self.__socket.setblocking(False)
 
         self.__incoming_buffer = array.array("B", (0 for _ in range(65536)))
-        self.__outgoing_queue = collections.deque()
+        self.__outgoing_queue = collections.deque(maxlen=1000000)
 
         self.__routing_table = {}  # type: typing.Dict[NodeID, NodeAddress]
 


### PR DESCRIPTION
Due to node will grow fast far away than normal network that allow to send
So the collections.deque will keep grow, till fill up memory, hang the system
Till magneticod crash, and restart it again.
So add maxlen parameter to limit the deque.

But the following question is, 
I found that magneticod only fetch metadata when magneticod start first couple minutes.
temporarily workaround, Create another timer process to kill magneticod
for example, create a new windows in the sceen
and execute
while true; do echo `date`: ctrl -c magneticod; kill -2 `pgrep magneticod`; sleep 120; done