### PR TITLE
Add uvloop as install dependency

### DIFF
--- a/magneticod/setup.py
+++ b/magneticod/setup.py
@@ -24,7 +24,8 @@ setup(
     install_requires=[
         "appdirs >= 1.4.3",
         "bencoder.pyx >= 1.1.3",
-        "humanfriendly"
+        "humanfriendly",
+        "uvloop",
     ],
 
     classifiers=[


### PR DESCRIPTION
I wanted to check this out. Looks super cool. I got errors with docker:

```
Starting magnetico_magneticod_1 ...
Starting magnetico_magneticow_1 ...
Starting magnetico_magneticod_1
Starting magnetico_magneticow_1 ... done
Attaching to magnetico_magneticod_1, magnetico_magneticow_1
magneticod_1  | 2017-06-03 07:15:16,379  INFO      magneticod v0.4.0 started
magneticod_1  | 2017-06-03 07:15:16,379  ERROR     uvloop could not be imported, using the default asyncio implementation
magneticod_1  | Traceback (most recent call last):
magneticod_1  |   File "/usr/src/app/magneticod/__main__.py", line 42, in create_tasks
magneticod_1  |     import uvloop
magneticod_1  | ModuleNotFoundError: No module named 'uvloop'
magneticod_1  | 2017-06-03 07:15:16,380  INFO      SybilNode 01F379FE0EF1323213416680B11444050718C28B on ('0.0.0.0', 0) initialized!
magneticow_1  | 2017-06-03 07:15:16,715  INFO      Connecting to magneticod's database...
magneticow_1  | 2017-06-03 07:15:16,717  INFO      magneticow is ready to serve!
```

Looks like uvloop should be an install dependency, so I made that change and now it looks good:

```
Creating magnetico_magneticod_1 ...
Creating magnetico_magneticow_1 ...
Creating magnetico_magneticod_1
Creating magnetico_magneticow_1 ... done
Attaching to magnetico_magneticod_1, magnetico_magneticow_1
magneticod_1  | 2017-06-03 07:17:29,419  INFO      magneticod v0.4.0 started
magneticod_1  | 2017-06-03 07:17:29,422  INFO      uvloop is being used
magneticod_1  | 2017-06-03 07:17:29,422  INFO      SybilNode D0AA651997A3D07EADCA93F78113F985B2187C1F on ('0.0.0.0', 0) initialized!
magneticow_1  | 2017-06-03 07:17:30,204  INFO      Connecting to magneticod's database...
magneticow_1  | 2017-06-03 07:17:30,205  INFO      magneticow is ready to serve!
```

If this is a dumb fix, and it might be because it's really late and I've no idea what I'm doing in your code base, you can say so, it won't hurt my feelings.