### PR TITLE
Removed ext_modules section from magneticod/setup.py

### DIFF
--- a/magneticod/setup.py
+++ b/magneticod/setup.py
@@ -10,7 +10,6 @@ def read_file(path):
 def run_setup():
     install_requirements = [
         "appdirs >= 1.4.3",
-        "bencoder.pyx >= 1.1.3",
         "humanfriendly",
         "better_bencode >= 0.2.1"
     ]

--- a/magneticod/setup.py
+++ b/magneticod/setup.py
@@ -44,14 +44,7 @@ def run_setup():
             "Operating System :: POSIX :: Linux",
             "Programming Language :: Python :: 3 :: Only",
             "Programming Language :: Python :: Implementation :: CPython",
-        ],
-
-        ext_modules=[
-            Extension(
-                "magneticod.bencoder._fast",
-                sources=["magneticod/bencoder/_fast.c"],
-            ),
-        ],
+        ]
     )
 
 


### PR DESCRIPTION
The `magneticod/bencoder/_fast.c` file was removed in `ec708db`, this section prevents building the extension.