### PR TITLE
magneticow: configurable pagination per-page limit and off-by-one issue

### DIFF
--- a/magneticow/magneticow/__main__.py
+++ b/magneticow/magneticow/__main__.py
@@ -87,6 +87,11 @@ def parse_args() -> argparse.Namespace:
         help="the pair(s) of username and password for basic HTTP authentication"
     )
 
+    parser.add_argument(
+        '--per-page', dest='perpage', action="store", type=int, required=False, default=20,
+        help="number of torrents to list per page by default"
+    )
+
     return parser.parse_args(sys.argv[1:])
 
 if __name__ == "__main__":

--- a/magneticow/magneticow/magneticow.py
+++ b/magneticow/magneticow/magneticow.py
@@ -126,7 +126,7 @@ def torrents():
         context["next_page_exists"] = False
 
     if app.arguments.noauth:
-        context["subscription_url"] = "/feed/?filter%s" % search
+        context["subscription_url"] = "/feed/?filter=%s" % search
     else:
         username, password = flask.request.authorization.username, flask.request.authorization.password
         context["subscription_url"] = "/feed?filter=%s&hash=%s" % (

--- a/magneticow/magneticow/templates/torrents.html
+++ b/magneticow/magneticow/templates/torrents.html
@@ -75,6 +75,7 @@
     {% if sorted_by %}
         <input type="text" name="sort_by" value="{{ sorted_by }}" hidden>
     {% endif %}
+        <input type="text" name="limit" value="{{ limit }}" hidden>
         <input type="number" name="page" value="{{ page - 1 }}" hidden>
     </form>
     <form action="/torrents" method="get">
@@ -83,6 +84,7 @@
     {% if sorted_by %}
         <input type="text" name="sort_by" value="{{ sorted_by }}" hidden>
     {% endif %}
+        <input type="text" name="limit" value="{{ limit }}" hidden>
         <input type="number" name="page" value="{{ page + 1 }}" hidden>
     </form>
 </footer>


### PR DESCRIPTION
Fixes an off-by-one issue in the pagination.

When 20 torrents are on the page it already allows to visit the next page, while it should only allow this when `len > 20`.