### PR TITLE
Add instructions for building standalone static Linux binaries

### DIFF
--- a/magneticod/Dockerfile.build
+++ b/magneticod/Dockerfile.build
@@ -1,0 +1,12 @@
+# python 3.5 is the latest version that works with the stable version of pyinstaller
+FROM python:3.5
+
+RUN mkdir -p /usr/src/app
+
+WORKDIR /usr/src/app
+
+COPY . .
+RUN pip install -e .
+RUN pyinstaller magneticod.spec
+RUN pip install pyinstaller
+CMD ["base64", "-w 0", "dist/magneticod"]

--- a/magneticod/README.rst
+++ b/magneticod/README.rst
@@ -103,6 +103,17 @@ Instructions
     Keep **magneticod** running so that when you finish installing **magneticow**, database will be populated and you
     can see some results.
 
+Alternate instructions
+======================
+
+For building standalone static **magneticod** binaries (using pyinstaller): ::
+
+       docker build -t magneticod_builder -f Dockerfile.build .
+       docker run --rm -t magneticod_builder | base64 -d > magneticod
+       chmod +x magneticod
+
+You can now start **magneticod** by executing ``./magneticod``, as you normally would.
+
 Using
 =====
 **magneticod** does not require user interference to operate, once it starts running. Hence, there is no "user manual",

--- a/magneticod/magneticod.spec
+++ b/magneticod/magneticod.spec
@@ -1,0 +1,54 @@
+# -*- mode: python -*-
+
+block_cipher = None
+
+# from https://github.com/pyinstaller/pyinstaller/wiki/Recipe-Setuptools-Entry-Point
+def Entrypoint(dist, group, name,
+               scripts=None, pathex=None, hiddenimports=None,
+               hookspath=None, excludes=None, runtime_hooks=None):
+    import pkg_resources
+
+    # get toplevel packages of distribution from metadata
+    def get_toplevel(dist):
+        distribution = pkg_resources.get_distribution(dist)
+        if distribution.has_metadata('top_level.txt'):
+            return list(distribution.get_metadata('top_level.txt').split())
+        else:
+            return []
+
+    hiddenimports = hiddenimports or []
+    packages = []
+    for distribution in hiddenimports:
+        packages += get_toplevel(distribution)
+
+    scripts = scripts or []
+    pathex = pathex or []
+    # get the entry point
+    ep = pkg_resources.get_entry_info(dist, group, name)
+    # insert path of the egg at the verify front of the search path
+    pathex = [ep.dist.location] + pathex
+    # script name must not be a valid module name to avoid name clashes on import
+    script_path = os.path.join(workpath, name + '-script.py')
+    print ("creating script for entry point", dist, group, name)
+    with open(script_path, 'w') as fh:
+        print("import", ep.module_name, file=fh)
+        print("%s.%s()" % (ep.module_name, '.'.join(ep.attrs)), file=fh)
+        for package in packages:
+            print ("import", package, file=fh)
+
+    return Analysis([script_path] + scripts, pathex, hiddenimports, hookspath, excludes, runtime_hooks)
+
+a = Entrypoint( 'magneticod', 'console_scripts', 'magneticod' )
+
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          name='magneticod',
+          debug=False,
+          strip=False,
+          upx=True,
+          console=True )

--- a/magneticow/Dockerfile.build
+++ b/magneticow/Dockerfile.build
@@ -1,0 +1,14 @@
+# python 3.5 is the latest version that works with the stable version of pyinstaller
+FROM python:3.5
+
+RUN mkdir -p /usr/src/app
+
+WORKDIR /usr/src/app
+
+COPY . .
+# need to latest version to work around the 'yield inside async function' error (jinja2)
+RUN pip install jinja2==2.8.1
+RUN pip install pyinstaller
+RUN pip install -e .
+RUN pyinstaller magneticow.spec
+CMD ["base64", "-w 0", "dist/magneticow"]

--- a/magneticow/README.rst
+++ b/magneticow/README.rst
@@ -104,6 +104,17 @@ Instructions
 
        systemctl --user stop magneticow
 
+Alternate instructions
+======================
+
+For building standalone static **magneticow** binaries (using pyinstaller): ::
+
+       docker build -t magneticow_builder -f Dockerfile.build .
+       docker run --rm -t magneticow_builder | base64 -d > magneticow
+       chmod +x magneticow
+
+You can now start **magneticow** by executing ``./magneticow``, as you normally would. If you get the ``magneticow is a folder``, try to move to a different directory with no **magneticow** folder.
+
 Using
 =====
 **magneticow** does not require user interference to operate, once it starts running. Hence, there is no "user manual",

--- a/magneticow/magneticow.spec
+++ b/magneticow/magneticow.spec
@@ -1,0 +1,83 @@
+# -*- mode: python -*-
+
+block_cipher = None
+
+# from https://github.com/pyinstaller/pyinstaller/wiki/Recipe-Setuptools-Entry-Point
+def Entrypoint(dist, group, name,
+               scripts=None, pathex=None, hiddenimports=None,
+               hookspath=None, excludes=None, runtime_hooks=None):
+    import pkg_resources
+
+    # get toplevel packages of distribution from metadata
+    def get_toplevel(dist):
+        distribution = pkg_resources.get_distribution(dist)
+        if distribution.has_metadata('top_level.txt'):
+            return list(distribution.get_metadata('top_level.txt').split())
+        else:
+            return []
+
+    hiddenimports = hiddenimports or []
+    packages = []
+    for distribution in hiddenimports:
+        packages += get_toplevel(distribution)
+
+    scripts = scripts or []
+    pathex = pathex or []
+    # get the entry point
+    ep = pkg_resources.get_entry_info(dist, group, name)
+    # insert path of the egg at the verify front of the search path
+    pathex = [ep.dist.location] + pathex
+    # script name must not be a valid module name to avoid name clashes on import
+    script_path = os.path.join(workpath, name + '-script.py')
+    print ("creating script for entry point", dist, group, name)
+    with open(script_path, 'w') as fh:
+        print("import", ep.module_name, file=fh)
+        print("%s.%s()" % (ep.module_name, '.'.join(ep.attrs)), file=fh)
+        for package in packages:
+            print ("import", package, file=fh)
+
+    return Analysis([script_path] + scripts, pathex, hiddenimports, hookspath, excludes, runtime_hooks)
+
+a = Entrypoint( 'magneticow', 'console_scripts', 'magneticow' )
+
+
+# see https://stackoverflow.com/questions/35811448/pyinstaller-jinja2-templatenotfound for embedding flask templates
+def collect_pkg_data(package, include_py_files=False, subdir=None):
+    import os
+    from PyInstaller.utils.hooks import get_package_paths, remove_prefix, PY_IGNORE_EXTENSIONS
+
+    # Accept only strings as packages.
+    if type(package) is not str:
+        raise ValueError
+
+    pkg_base, pkg_dir = get_package_paths(package)
+    if subdir:
+        pkg_dir = os.path.join(pkg_dir, subdir)
+    # Walk through all file in the given package, looking for data files.
+    data_toc = TOC()
+    for dir_path, dir_names, files in os.walk(pkg_dir):
+        for f in files:
+            extension = os.path.splitext(f)[1]
+            if include_py_files or (extension not in PY_IGNORE_EXTENSIONS):
+                source_file = os.path.join(dir_path, f)
+                dest_folder = remove_prefix(dir_path, os.path.dirname(pkg_base) + os.sep)
+                dest_file = os.path.join(dest_folder, f)
+                data_toc.append((dest_file, source_file, 'DATA'))
+
+    return data_toc
+
+pkg_data = collect_pkg_data('magneticow') 
+
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          pkg_data,
+          name='magneticow',
+          debug=False,
+          strip=False,
+          upx=True,
+          console=True )


### PR DESCRIPTION
Static binaries for magneticow and magneticod make deploying magnetico really easy, regardless of the
tools present on the target systems.