### PR TITLE
Fix adding of single file torrents

### DIFF
--- a/cmd/magneticod/bittorrent/operations.go
+++ b/cmd/magneticod/bittorrent/operations.go
@@ -361,6 +361,14 @@ func (ms *MetadataSink) awaitMetadata(infoHash metainfo.Hash, peer Peer) {
 	}
 
 	var files []persistence.File
+	// If there is only one file, there won't be a Files slice. That's why we need to add it here
+	if len(info.Files) == 0 {
+		files = append(files, persistence.File{
+			Size: info.Length,
+			Path: info.Name,
+		})
+	}
+
 	for _, file := range info.Files {
 		if file.Length < 0 {
 			zap.L().Debug(


### PR DESCRIPTION
The unmarshall method won't add a Files slice to the Info struct. So adding the torrent to the db will fail later on because the total size is 0. This can be fixed by adding the FileInfo with the name and length of the whole torrent to the Files slice.