### PR TITLE
Better distinguish opFlags from cmdFlags

### DIFF
--- a/cmd/magneticod/dht/mainline/protocol.go
+++ b/cmd/magneticod/dht/mainline/protocol.go
@@ -28,7 +28,7 @@ type ProtocolEventHandlers struct {
 	OnPingORAnnouncePeerResponse func(*Message, net.Addr)
 }
 
-func NewProtocol(laddr string, eventHandlers ProtocolEventHandlers) (p *Protocol) {
+func NewProtocol(laddr *net.UDPAddr, eventHandlers ProtocolEventHandlers) (p *Protocol) {
 	p = new(Protocol)
 	p.transport = NewTransport(laddr, p.onMessage)
 	p.eventHandlers = eventHandlers

--- a/cmd/magneticod/dht/mainline/service.go
+++ b/cmd/magneticod/dht/mainline/service.go
@@ -37,7 +37,7 @@ type TrawlingServiceEventHandlers struct {
 	OnResult func(TrawlingResult)
 }
 
-func NewTrawlingService(laddr string, eventHandlers TrawlingServiceEventHandlers) *TrawlingService {
+func NewTrawlingService(laddr *net.UDPAddr, eventHandlers TrawlingServiceEventHandlers) *TrawlingService {
 	service := new(TrawlingService)
 	service.protocol = NewProtocol(
 		laddr,

--- a/cmd/magneticod/dht/mainline/transport.go
+++ b/cmd/magneticod/dht/mainline/transport.go
@@ -19,14 +19,10 @@ type Transport struct {
 	onMessage func(*Message, net.Addr)
 }
 
-func NewTransport(laddr string, onMessage func(*Message, net.Addr)) *Transport {
+func NewTransport(laddr *net.UDPAddr, onMessage func(*Message, net.Addr)) *Transport {
 	transport := new(Transport)
 	transport.onMessage = onMessage
-	var err error
-	transport.laddr, err = net.ResolveUDPAddr("udp", laddr)
-	if err != nil {
-		zap.L().Panic("Could not resolve the UDP address for the trawler!", zap.Error(err))
-	}
+	transport.laddr = laddr
 
 	return transport
 }

--- a/cmd/magneticod/dht/managers.go
+++ b/cmd/magneticod/dht/managers.go
@@ -1,6 +1,9 @@
 package dht
 
-import "github.com/boramalper/magnetico/cmd/magneticod/dht/mainline"
+import (
+	"github.com/boramalper/magnetico/cmd/magneticod/dht/mainline"
+	"net"
+)
 
 type TrawlingManager struct {
 	// private
@@ -8,13 +11,10 @@ type TrawlingManager struct {
 	services []*mainline.TrawlingService
 }
 
-func NewTrawlingManager(mlAddrs []string) *TrawlingManager {
+func NewTrawlingManager(mlAddrs []*net.UDPAddr) *TrawlingManager {
 	manager := new(TrawlingManager)
 	manager.output = make(chan mainline.TrawlingResult)
 
-	if mlAddrs == nil {
-		mlAddrs = []string{"0.0.0.0:0"}
-	}
 	for _, addr := range mlAddrs {
 		manager.services = append(manager.services, mainline.NewTrawlingService(
 			addr,

--- a/pkg/persistence/interface.go
+++ b/pkg/persistence/interface.go
@@ -74,19 +74,14 @@ type TorrentMetadata struct {
 	NFiles       uint
 }
 
-func MakeDatabase(rawURL string, logger *zap.Logger) (Database, error) {
+func MakeDatabase(dbURL *url.URL, logger *zap.Logger) (Database, error) {
 	if logger != nil {
 		zap.ReplaceGlobals(logger)
 	}
 
-	url_, err := url.Parse(rawURL)
-	if err != nil {
-		return nil, err
-	}
-
-	switch url_.Scheme {
+	switch dbURL.Scheme {
 	case "sqlite3":
-		return makeSqlite3Database(url_)
+		return makeSqlite3Database(dbURL)
 
 	case "postgresql":
 		return nil, fmt.Errorf("postgresql is not yet supported!")


### PR DESCRIPTION
To make the opFlags more useful they should be typed, otherwise they are
just a duplication of the cmdFlags. Now we can also catch more errors
much earlier during the parsing process. The flags also have been
renamed to give them a more expressive name. All flags have a short
version now and support for environment variables has been added.