### PR TITLE
log peer id as hex and improve some log messages

### DIFF
--- a/cmd/magneticod/dht/mainline/service.go
+++ b/cmd/magneticod/dht/mainline/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/anacrolix/torrent"
 	"github.com/anacrolix/torrent/metainfo"
 	"go.uber.org/zap"
+	"encoding/hex"
 )
 
 type TrawlingResult struct {
@@ -69,7 +70,10 @@ func (s *TrawlingService) Start() {
 	s.protocol.Start()
 	go s.trawl()
 
-	zap.L().Info("Trawling Service started!")
+	zap.L().Info("Trawling Service started!",
+		zap.String("Address", s.protocol.transport.laddr.String()),
+		zap.String("ID", hex.EncodeToString(s.trueNodeID)),
+	)
 }
 
 func (s *TrawlingService) Terminate() {
@@ -82,7 +86,10 @@ func (s *TrawlingService) trawl() {
 		if len(s.routingTable) == 0 {
 			s.bootstrap()
 		} else {
-			zap.L().Debug("Latest status:", zap.Int("n", len(s.routingTable)))
+			zap.L().Debug("Routing table status:",
+				zap.String("ID", hex.EncodeToString(s.trueNodeID)),
+				zap.Int("peers", len(s.routingTable)),
+			)
 			s.findNeighbors()
 			s.routingTable = make(map[string]net.Addr)
 		}

--- a/cmd/magneticod/dht/mainline/transport.go
+++ b/cmd/magneticod/dht/mainline/transport.go
@@ -69,14 +69,20 @@ func (t *Transport) readMessages() {
 			if strings.HasSuffix(err.Error(), "use of closed network connection") {
 				break
 			} else {
-				zap.L().Debug("Could NOT read an UDP packet!", zap.Error(err))
+				zap.L().Debug("Could NOT read an UDP packet!",
+					zap.Error(err),
+					zap.String("peer", addr.String()),
+				)
 			}
 		}
 
 		var msg Message
 		err = bencode.Unmarshal(buffer[:n], &msg)
 		if err != nil {
-			zap.L().Debug("Could NOT unmarshal packet data!", zap.Error(err))
+			zap.L().Debug("Could NOT unmarshal packet data!",
+				zap.Error(err),
+				zap.String("peer", addr.String()),
+			)
 		}
 
 		t.onMessage(&msg, addr)

--- a/pkg/persistence/sqlite3.go
+++ b/pkg/persistence/sqlite3.go
@@ -342,7 +342,7 @@ func (db *sqlite3Database) GetStatistics(n uint, to string) (*Statistics, error)
 	if err != nil {
 		return nil, fmt.Errorf("parsing @to error: %s", err.Error())
 	}
-
+	zap.L().Debug("Parsed Date for statistics", zap.Time("to_time", *to_time), zap.Int("granularity", int(granularity)))
 	// TODO
 
 	return nil, nil


### PR DESCRIPTION
The peerid was previously logged as utf8 string, but hex is more useful and readable. Also log our own peer id on startup and make some other messages more clear.