### PR TITLE
fixed compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 .PHONY: test format magneticod magneticow ensure test-magneticod test-magneticow test-persistence image image-magneticow image-magneticod
 
-all: test magneticod magneticow
+all: ensure magneticod magneticow
 
 magneticod:
 	go install --tags fts5 "-ldflags=-s -w" github.com/boramalper/magnetico/cmd/magneticod
 
 magneticow:
 	# TODO: minify files!
-	go-bindata -o="cmd/magneticow/bindata.go" -prefix="cmd/magneticow/data/" cmd/magneticow/data/...
+	go-bindata -o="cmd/magneticow/bindata.go" -prefix="cmd/magneticow/data/" -pkg="main" cmd/magneticow/data/...
 	go install --tags fts5 "-ldflags=-s -w" github.com/boramalper/magnetico/cmd/magneticow
 
 image-magneticod:
@@ -37,4 +37,3 @@ format:
 	gofmt -w cmd/magneticod
 	gofmt -w cmd/magneticow
 	gofmt -w pkg/persistence
-


### PR DESCRIPTION
The original 0.7 release didn't come with indications how to build the project.
This pull request aims at making this more clear.
The Makefile has been modified so that simply calling `make` produces all binaries.

The command `make test-magneticow` fails, but since I don't understand anything about go, I don't know why.