### PR TITLE
Create magneticod.service

### DIFF
--- a/magneticod.service
+++ b/magneticod.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=magneticod
+
+[Service]
+ExecStart=/usr/bin/magneticod -v
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I created this very basic Systemd unit from the template found here:  

https://www.freedesktop.org/software/systemd/man/systemd.unit.html

It runs as root, and expects magneticod to be installed in /usr/bin.  You'll find your config files in their usual place, though I did want to talk to @boramalper about using ~/.magnetico for everything instead of ~/.config or ~/.local.  It also restarts magneticod automatically in case of a crash.  

I'll make one for magneticow, too.  Of course, it will be basically the same thing.  

I'm interested in creating a "one-liner" bash script, designed for use as root, on a VPS, as well.