### PR TITLE
Fix go-bindata quirk and browser warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ magneticod:
 magneticow:
 	# TODO: minify files!
 	# https://github.com/kevinburke/go-bindata
-	go-bindata -o="cmd/magneticow/bindata.go" -prefix="cmd/magneticow/data/" cmd/magneticow/data/...
+	go-bindata -o="cmd/magneticow/bindata.go" -prefix="cmd/magneticow/data/" -pkg "main" cmd/magneticow/data/...
 	go install --tags fts5 "-ldflags=-s -w -X main.compiledOn=`date -u +%Y-%m-%dT%H:%M:%SZ`" ./cmd/magneticow
 
 image-magneticod:

--- a/cmd/magneticow/handlers.go
+++ b/cmd/magneticow/handlers.go
@@ -137,6 +137,8 @@ func staticHandler(w http.ResponseWriter, r *http.Request) {
 	var contentType string
 	if strings.HasSuffix(r.URL.Path, ".css") {
 		contentType = "text/css; charset=utf-8"
+	} else if strings.HasSuffix(r.URL.Path, ".js") {
+		contentType = "text/javascript; charset=utf-8"
 	} else { // fallback option
 		contentType = http.DetectContentType(data)
 	}


### PR DESCRIPTION
Looks like go-bindata likes to call the package name in output files the same name as the parent directory.
This small update in the Makefile prevents that issue.

Also fix messages such as
```
The script from “https://magnetico.kescher.at/static/scripts/mustache-v2.3.0.min.js” was loaded even though its MIME type (“text/plain”) is not a valid JavaScript MIME type.
The script from “https://magnetico.kescher.at/static/scripts/common.js” was loaded even though its MIME type (“text/plain”) is not a valid JavaScript MIME type.
The script from “https://magnetico.kescher.at/static/scripts/torrents.js” was loaded even though its MIME type (“text/plain”) is not a valid JavaScript MIME type.
```

Signed-off-by: Jeremy Kescher <jeremy@kescher.at>