### PR TITLE
Magneticow: mobile-friendlier templates

### DIFF
--- a/cmd/magneticow/data/templates/homepage.html
+++ b/cmd/magneticow/data/templates/homepage.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>magneticow</title>
     <link rel="stylesheet" href="static/styles/reset.css">
     <link rel="stylesheet" href="static/styles/essential.css">

--- a/cmd/magneticow/data/templates/statistics.html
+++ b/cmd/magneticow/data/templates/statistics.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Statistics - magneticow</title>
-
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="static/styles/reset.css">
     <link rel="stylesheet" href="static/styles/essential.css">
     <link rel="stylesheet" href="static/styles/statistics.css">

--- a/cmd/magneticow/data/templates/torrent.html
+++ b/cmd/magneticow/data/templates/torrent.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ .T.Name }} - magnetico</title>
     <link rel="stylesheet" href="/static/styles/reset.css">
     <link rel="stylesheet" href="/static/styles/essential.css">

--- a/cmd/magneticow/data/templates/torrents.html
+++ b/cmd/magneticow/data/templates/torrents.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Search - magneticow</title>
-
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="static/styles/reset.css">
     <link rel="stylesheet" href="static/styles/essential.css">
     <link rel="stylesheet" href="static/styles/torrents.css">


### PR DESCRIPTION
Adding
```
<meta name="viewport" content="width=device-width, initial-scale=1">
```
in all HTML template files **changes nothing on desktop devices**, however, it changes things on mobile, **making search bars and links easier to reach without having to zoom around**. Left picture is without, right picture is with tag.
<p float="left">
  <img src=https://user-images.githubusercontent.com/23276523/58049231-a3f53d80-7b4c-11e9-936a-4632c613e3d2.png width="300" />
  <img src=https://user-images.githubusercontent.com/23276523/58049235-a6579780-7b4c-11e9-9a30-3d1128853cc6.png width="300" /> 
</p>
<p float="left">
<img src=https://user-images.githubusercontent.com/23276523/58050245-16ffb380-7b4f-11e9-9e60-8b9fd93822d0.png width="300" />
<img src=https://user-images.githubusercontent.com/23276523/58050247-19620d80-7b4f-11e9-9887-53e1c36a891f.png width="300" />
</p>
<p>Okay, I admit that maybe for the statistics screen, it might sometimes be weird when condensed together but still better than the zoomed out mess.</p>
<p float="left">
<img src=https://user-images.githubusercontent.com/23276523/58050573-03088180-7b50-11e9-81d4-66f1e4015454.png width="300" />
<img src=https://user-images.githubusercontent.com/23276523/58050581-0c91e980-7b50-11e9-8873-e7b0b8ff13c0.png width="300" />
</p>
<p float="left">
<img src=https://user-images.githubusercontent.com/23276523/58050712-61cdfb00-7b50-11e9-8993-560c0edea4b8.png width="300" />
<img src=https://user-images.githubusercontent.com/23276523/58050722-6abecc80-7b50-11e9-8fae-66bbda7de9e4.png width="300" />
</p>