### PR TITLE
Fix link to Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ central entity*.
 
 ## Features
 - Easy installation & minimal requirements:
-  - [Pre-compiled static binaries](https://github.com/boramalper/magnetico/releases) and [Docker images](https://cloud.docker.com/repository/docker/boramalper/magnetico) are provided.
+  - [Pre-compiled static binaries](https://github.com/boramalper/magnetico/releases) and [Docker images](https://hub.docker.com/u/boramalper) are provided.
   - Root access is *not* required to install or to use.
 - Near-zero configuration:
   - Both programs work out of the box, and **magneticow** can be used without a web-server too.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ for torrents in the network, hence removing the need for centralised torrent web
 2. Install **magneticow** afterwards by following its
    [installation instructions](cmd/magneticow/README.md).
 
-*Alternatively*, just grab it from [Docker Hub](https://cloud.docker.com/repository/docker/boramalper/magnetico)!
+*Alternatively*, just grab it from [Docker Hub](https://hub.docker.com/u/boramalper)!
 
 ## License
 


### PR DESCRIPTION
It was pointing to "your" view of the repositories, not the public page.