### PR TITLE
Fix docker-compose.yml, allow to run from dockerhub or build own image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,21 @@ magneticow:
 	go-bindata -o="cmd/magneticow/bindata.go" -prefix="cmd/magneticow/data/" cmd/magneticow/data/...
 	go install --tags fts5 "-ldflags=-s -w -X main.compiledOn=`date -u +%Y-%m-%dT%H:%M:%SZ`" ./cmd/magneticow
 
+.PHONY: docker
+docker: docker_up docker_logs
+
+.PHONY: docker_up
+docker_up:
+	docker-compose up -d
+
+.PHONY: docker_down
+docker_down:
+	docker-compose down
+
+.PHONY: docker_logs
+docker_logs:
+	docker-compose logs -ft --tail=10
+
 image-magneticod:
 	docker build -t boramalper/magneticod -f Dockerfile.magneticod .
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,25 @@ for torrents in the network, hence removing the need for centralised torrent web
 2. Install **magneticow** afterwards by following its
    [installation instructions](cmd/magneticow/README.md).
 
-*Alternatively*, just grab it from [Docker Hub](https://hub.docker.com/u/boramalper)!
+### Docker
+
+Run **magneticod** and **magneticow** with:
+
+``` bash
+make docker
+```
+
+It will run magnetico from already built image on [Docker Hub](https://hub.docker.com/u/boramalper)!
+
+You should access magneticow at <http://localhost:8080>.
+
+To build fresh images from source, first run:
+
+``` bash
+make image
+```
+
+Then run `make docker`. It ensures you run updated images of magnetico.
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,19 +2,13 @@ version: "2"
 
 services:
   magneticod:
-    build:
-      image: boramalper/magneticod
-#      context: .
-#      dockerfile: Dockerfile.magneticod
+    image: boramalper/magneticod
     volumes:
       - magneticod-data:/root/.local/share/magneticod
       - magneticod-config:/root/.config/magneticod
 
   magneticow:
-    build:
-      image: boramalper/magneticow
-#      context: .
-#      dockerfile: Dockerfile.magneticow
+    image: boramalper/magneticow
     volumes:
       - magneticod-data:/root/.local/share/magneticod
     depends_on:


### PR DESCRIPTION
Fixes #232 

Fix docker-compose, allow to run magnetico with docker hub images with `make docker`, or reuse fresh images built from `make image`.