### PR TITLE
Fixes `/torrents/{{hash}}` page when serving MagneticoW from a sub-path

### DIFF
--- a/cmd/magneticow/data/static/scripts/torrent.js
+++ b/cmd/magneticow/data/static/scripts/torrent.js
@@ -9,7 +9,7 @@
 
 
 window.onload = function () {
-    let infoHash = window.location.pathname.split("/")[2];
+    let infoHash = window.location.pathname.split("/").pop();
 
     fetch("/api/v0.1/torrents/" + infoHash).then(x => x.json()).then(x => {
         document.querySelector("title").innerText = x.name + " - magneticow";


### PR DESCRIPTION
MagneticoW is currently **not** reverse-proxiable out-of-the-box from a sub-path. Some URIs are relative, others absolute. No environment variable nor configuration setting may allow us to specify a "public URL" or even a "base path" to make the internal Go router generate _correct_ URLs.
Although, it's _possible_ to come up with proper NGINX's `sub_filter` or Apache's `proxy_html`/`substitute` modules usages to fix them.
This patch back-ports @rnhmjoj's "fix" to avoid crash when extracting hash from URL on `/torrents/{{ hash }}` page.

> See #111.